### PR TITLE
Remove double dependency on inquirer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "Martin Hansen <martin@martinhansen.no>",
   "license": "ISC",
   "devDependencies": {
-    "inquirer": "^0.9.0",
     "istanbul": "^0.3.8",
     "jscs": "^1.6.1",
     "jshint": "^2.5.6",


### PR DESCRIPTION
When running `npm install`, npm runs the following warning

```
npm WARN package.json Dependency 'inquirer' exists in both dependencies and devDependencies, using 'inquirer@^0.9.0' from dependencies
```