### PR TITLE
proper dependency paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@
 var util = require('util');
 var chalk = require('chalk');
 var figures = require('figures');
-var Base = require('./node_modules/inquirer/lib/prompts/base');
-var Choices = require('./node_modules/inquirer/lib/objects/choices');
-var observe = require('./node_modules/inquirer/lib/utils/events');
-var utils = require('./node_modules/inquirer/lib/utils/readline');
-var Paginator = require('./node_modules/inquirer/lib/utils/paginator');
+var Base = require('inquirer/lib/prompts/base');
+var Choices = require('inquirer/lib/objects/choices');
+var observe = require('inquirer/lib/utils/events');
+var utils = require('inquirer/lib/utils/readline');
+var Paginator = require('inquirer/lib/utils/paginator');
 var readline = require('readline');
 
 /**


### PR DESCRIPTION
Because of [how `require` works](https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders), NPM dependencies are not allowed to begin with `.`, `..` or `/`. This worked previously, because `npm@2.x` stored all dependencies and their dependencies in a non-flattened tree. `npm@3.x`, however, flattens the tree, so requiring this module fails.