### PR TITLE
Inquirer 1.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var figures = require('figures');
 var Base = require('inquirer/lib/prompts/base');
 var Choices = require('inquirer/lib/objects/choices');
 var observe = require('inquirer/lib/utils/events');
-var utils = require('inquirer/lib/utils/readline');
 var Paginator = require('inquirer/lib/utils/paginator');
 var readline = require('readline');
 
@@ -75,33 +74,31 @@ Prompt.prototype._run = function(cb) {
  */
 
 Prompt.prototype.render = function() {
-  var cursor = 0;
-
   // Render question
-  var message = this.getQuestion();
+  var content = this.getQuestion();
+  var bottomContent = '';
 
   if (this.firstRender) {
-    message += chalk.dim('(Use arrow keys or type to search)');
+    content += chalk.dim('(Use arrow keys or type to search)');
   }
   // Render choices or answer depending on the state
   if (this.status === 'answered') {
-    message += chalk.cyan(this.answer);
+    content += chalk.cyan(this.answer);
   } else if (this.searching) {
-    message += this.rl.line + '\n  ' + chalk.dim('Searching...');
+    content += this.rl.line;
+    bottomContent += '  ' + chalk.dim('Searching...');
   } else if (this.currentChoices.length) {
     var choicesStr = listRender(this.currentChoices, this.selected);
-    message += this.rl.line + '\n' + this.paginator.paginate(choicesStr, this.selected);
+    content += this.rl.line;
+    bottomContent += this.paginator.paginate(choicesStr, this.selected);
   } else {
-    message += this.rl.line + '\n  ' + chalk.yellow('No results...');
+    content += this.rl.line;
+    bottomContent += '  ' + chalk.yellow('No results...');
   }
-
-  cursor = cursor + message.split('\n').length - 1;
 
   this.firstRender = false;
 
-  this.screen.render(message, {
-    cursor: cursor
-  });
+  this.screen.render(content, bottomContent);
 };
 
 /**
@@ -124,7 +121,6 @@ Prompt.prototype.onSubmit = function(line) {
   this.render();
 
   this.screen.done();
-  utils.showCursor(this.rl);
 
   this.done(choice.value);
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ Prompt.prototype._run = function(cb) {
   var self = this;
   self.done = cb;
 
+  if (self.rl.history instanceof Array) {
+    self.rl.history = [];
+  }
+
   var events = observe(self.rl);
 
   events.line.takeWhile(dontHaveAnswer).forEach(self.onSubmit.bind(this));

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ var figures = require('figures');
 var Base = require('inquirer/lib/prompts/base');
 var Choices = require('inquirer/lib/objects/choices');
 var observe = require('inquirer/lib/utils/events');
+var utils = require('inquirer/lib/utils/readline');
 var Paginator = require('inquirer/lib/utils/paginator');
-var readline = require('readline');
 
 /**
  * Module exports
@@ -123,7 +123,6 @@ Prompt.prototype.onSubmit = function(line) {
   this.screen.done();
 
   this.done(choice.value);
-
 };
 
 Prompt.prototype.search = function(searchTerm) {
@@ -179,7 +178,7 @@ Prompt.prototype.onKeypress = function(e) {
     this.selected = (this.selected < len - 1) ? this.selected + 1 : 0;
     this.ensureSelectedInRange();
     this.render();
-    readline.moveCursor(this.rl.output, -2, 0)
+    utils.up(this.rl, 2);
   } else if (keyName === 'up') {
     len = this.currentChoices.length;
     this.selected = (this.selected > 0) ? this.selected - 1 : len - 1;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "chalk": "^1.1.0",
     "figures": "^1.3.5",
-    "inquirer": "^0.9.0",
+    "inquirer": "^1.1.2",
     "lodash": "^3.10.1",
     "util": "^0.10.3"
   },

--- a/test/spec/indexSpec.js
+++ b/test/spec/indexSpec.js
@@ -206,7 +206,7 @@ describe('inquirer-autocomplete-prompt', function() {
   }
 
   function typeNonChar() {
-    rl.emit('keypress', '', {
+    rl.input.emit('keypress', '', {
       name: 'shift'
     });
   }
@@ -214,18 +214,18 @@ describe('inquirer-autocomplete-prompt', function() {
   function type(word) {
     word.split('').forEach(function(char) {
       rl.line = rl.line + char;
-      rl.emit('keypress', char)
+      rl.input.emit('keypress', char)
     });
   }
 
   function moveDown() {
-    rl.emit('keypress', '', {
+    rl.input.emit('keypress', '', {
       name: 'down'
     });
   }
 
   function moveUp() {
-    rl.emit('keypress', '', {
+    rl.input.emit('keypress', '', {
       name: 'up'
     });
   }

--- a/test/spec/indexSpec.js
+++ b/test/spec/indexSpec.js
@@ -202,11 +202,7 @@ describe('inquirer-autocomplete-prompt', function() {
   });
 
   function getPromiseForAnswer() {
-    return new Promise(function(resolve) {
-      prompt.run(function(answer) {
-        resolve(answer);
-      });
-    });
+    return prompt.run();
   }
 
   function typeNonChar() {


### PR DESCRIPTION
Updates the plugin to support Inquirer 1.x. I've tested it side by side with the old Inquirer and I think I've matched the behaviour.

However, I've only tested it in one environment (OS X, iTerm 2, node@6.2.2), so it's possible there are different behaviours in other environments due to the changes in framework from 0.x to 1.x.