### PR TITLE
Fixes a crash in suggestOnly mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.idea

--- a/index.js
+++ b/index.js
@@ -214,11 +214,13 @@ Prompt.prototype.onKeypress = function(e) {
   var keyName = (e.key && e.key.name) || undefined;
 
   if (keyName === 'tab' && this.opt.suggestOnly) {
-    this.rl.write(ansiEscapes.cursorLeft);
-    var autoCompleted = this.currentChoices.getChoice(this.selected).value;
-    this.rl.write(ansiEscapes.cursorForward(autoCompleted.length));
-    this.rl.line = autoCompleted
-    this.render();
+    if (this.currentChoices.getChoice(this.selected)) {
+      this.rl.write(ansiEscapes.cursorLeft);
+      var autoCompleted = this.currentChoices.getChoice(this.selected).value;
+      this.rl.write(ansiEscapes.cursorForward(autoCompleted.length));
+      this.rl.line = autoCompleted
+      this.render();
+    }
   } else if (keyName === 'down') {
     len = this.currentChoices.length;
     this.selected = (this.selected < len - 1) ? this.selected + 1 : 0;


### PR DESCRIPTION
In `suggestOnly` mode, if the user types the beginning of a command that is not in the list and press `tab` there is a fatal error and the app crashes.

To replicate the error, run the example and when it shows the first list type, for example, 'foo' and press tab.

This PS fixes the error checking if that command is part of the list, before trying to retrieve its value.