### PR TITLE
Remove unnecessary util dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "chalk": "^2.0.0",
     "figures": "^2.0.0",
     "inquirer": "3.2.0",
-    "run-async": "^2.3.0",
-    "util": "^0.10.3"
+    "run-async": "^2.3.0"
   },
   "scripts": {
     "lint": "jshint .",


### PR DESCRIPTION
'util' is a standard nodejs module: https://nodejs.org/api/util.html . The 'util' module being required here is a browser polyfill (https://github.com/defunctzombie/node-util) which is probably not intended.