### PR TITLE
Use undefined as default searchTerm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .idea
+*.sw*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [inquirer](https://github.com/SBoudrias/Inquirer.js) readme for meaning of a
 
 **Source** will be called with previous answers object and the current user input each time the user types, it **must** return a promise.
 
-**Source** will be called once at at first before the user types anything with **null** as the value. If a new search is triggered by user input it maintains the correct order, meaning that if the first call completes after the second starts, the results of the first call are never displayed.
+**Source** will be called once at at first before the user types anything with **undefined** as the value. If a new search is triggered by user input it maintains the correct order, meaning that if the first call completes after the second starts, the results of the first call are never displayed.
 
 **suggestOnly** is default **false**. Setting it to true turns the input into a normal text input. Meaning that pressing enter selects whatever value you currently have. And pressing tab autocompletes the currently selected value in the list. This way you can accept manual input instead of forcing a selection from the list.
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ Prompt.prototype._run = function(cb) {
   }
 
   //call once at init
-  self.search(null);
+  self.search(undefined);
 
   return this;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2788,21 +2788,6 @@
           "dev": true
         }
       }
-    },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
-      }
     }
   }
 }

--- a/test/spec/indexSpec.js
+++ b/test/spec/indexSpec.js
@@ -253,10 +253,10 @@ describe('inquirer-autocomplete-prompt', function() {
       }).to.throw(/source/);
     });
 
-    it('immediately calls source with null', function() {
+    it('immediately calls source with undefined', function() {
       prompt.run();
       sinon.assert.calledOnce(source);
-      sinon.assert.calledWithExactly(source, undefined, null);
+      sinon.assert.calledWithExactly(source, undefined, undefined);
     });
 
     describe('when it has some results', function() {


### PR DESCRIPTION
Use `undefined` can let us make use of function default parameters. As discussed in 
https://github.com/mokkabonna/inquirer-autocomplete-prompt/issues/54