### PR TITLE
Add Node.js version 10 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ node_js:
   - 6
   - 8
   - 9
+  - 10
 before_script:
   - npm install -g istanbul

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,46 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
       "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I="
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "chai": {
@@ -21,12 +52,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "assertion-error": {
@@ -47,7 +78,7 @@
           "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
           "dev": true,
           "requires": {
-            "type-detect": "4.0.3"
+            "type-detect": "^4.0.0"
           }
         },
         "get-func-name": {
@@ -75,9 +106,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -85,7 +116,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           },
           "dependencies": {
             "color-convert": {
@@ -93,7 +124,7 @@
               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
               "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
               "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
               },
               "dependencies": {
                 "color-name": {
@@ -115,7 +146,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           },
           "dependencies": {
             "has-flag": {
@@ -127,12 +158,45 @@
         }
       }
     },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -142,10 +206,64 @@
         }
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
     "fuzzy": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
       "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "inquirer": {
@@ -153,20 +271,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.0.tgz",
       "integrity": "sha1-RbRMIWDHKddXjFQGCz7tlEh7tCs=",
       "requires": {
-        "ansi-escapes": "2.0.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^2.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -179,7 +297,7 @@
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           },
           "dependencies": {
             "restore-cursor": {
@@ -187,8 +305,8 @@
               "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
               "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
               "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
               },
               "dependencies": {
                 "onetime": {
@@ -196,7 +314,7 @@
                   "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
                   "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
                   "requires": {
-                    "mimic-fn": "1.1.0"
+                    "mimic-fn": "^1.0.0"
                   },
                   "dependencies": {
                     "mimic-fn": {
@@ -225,9 +343,9 @@
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
           "integrity": "sha1-UsJJo5gbm6GHx8rPW+tQvx2Rprw=",
           "requires": {
-            "iconv-lite": "0.4.19",
-            "jschardet": "1.6.0",
-            "tmp": "0.0.33"
+            "iconv-lite": "^0.4.17",
+            "jschardet": "^1.4.2",
+            "tmp": "^0.0.33"
           },
           "dependencies": {
             "iconv-lite": {
@@ -245,7 +363,7 @@
               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
               "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
               "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
               },
               "dependencies": {
                 "os-tmpdir": {
@@ -272,7 +390,7 @@
           "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
           "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
           "requires": {
-            "rx-lite": "4.0.8"
+            "rx-lite": "*"
           }
         },
         "string-width": {
@@ -280,8 +398,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -296,7 +414,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -313,26 +431,32 @@
         }
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "istanbul": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -353,11 +477,11 @@
           "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
           "dev": true,
           "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
           },
           "dependencies": {
             "estraverse": {
@@ -378,12 +502,12 @@
               "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
               "dev": true,
               "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
               },
               "dependencies": {
                 "deep-is": {
@@ -404,8 +528,8 @@
                   "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                   "dev": true,
                   "requires": {
-                    "prelude-ls": "1.1.2",
-                    "type-check": "0.3.2"
+                    "prelude-ls": "~1.1.2",
+                    "type-check": "~0.3.2"
                   }
                 },
                 "prelude-ls": {
@@ -420,7 +544,7 @@
                   "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                   "dev": true,
                   "requires": {
-                    "prelude-ls": "1.1.2"
+                    "prelude-ls": "~1.1.2"
                   }
                 }
               }
@@ -432,7 +556,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               },
               "dependencies": {
                 "amdefine": {
@@ -458,11 +582,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "inflight": {
@@ -471,8 +595,8 @@
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
@@ -495,7 +619,7 @@
               "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -504,7 +628,7 @@
                   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -538,10 +662,10 @@
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "optimist": {
@@ -550,8 +674,8 @@
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "dev": true,
               "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
               },
               "dependencies": {
                 "minimist": {
@@ -574,7 +698,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               },
               "dependencies": {
                 "amdefine": {
@@ -592,9 +716,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
               },
               "dependencies": {
                 "source-map": {
@@ -618,9 +742,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
                     "window-size": "0.1.0"
                   },
                   "dependencies": {
@@ -638,8 +762,8 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                       },
                       "dependencies": {
@@ -650,8 +774,8 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "align-text": "0.1.4",
-                            "lazy-cache": "1.0.4"
+                            "align-text": "^0.1.3",
+                            "lazy-cache": "^1.0.3"
                           },
                           "dependencies": {
                             "align-text": {
@@ -661,9 +785,9 @@
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "kind-of": "3.2.2",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.6.1"
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
                               },
                               "dependencies": {
                                 "kind-of": {
@@ -673,7 +797,7 @@
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "is-buffer": "1.1.6"
+                                    "is-buffer": "^1.1.5"
                                   },
                                   "dependencies": {
                                     "is-buffer": {
@@ -717,7 +841,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "align-text": "0.1.4"
+                            "align-text": "^0.1.1"
                           },
                           "dependencies": {
                             "align-text": {
@@ -727,9 +851,9 @@
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "kind-of": "3.2.2",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.6.1"
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
                               },
                               "dependencies": {
                                 "kind-of": {
@@ -739,7 +863,7 @@
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "is-buffer": "1.1.6"
+                                    "is-buffer": "^1.1.5"
                                   },
                                   "dependencies": {
                                     "is-buffer": {
@@ -804,8 +928,8 @@
           "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           },
           "dependencies": {
             "argparse": {
@@ -814,7 +938,7 @@
               "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
               "dev": true,
               "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
               },
               "dependencies": {
                 "sprintf-js": {
@@ -856,7 +980,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           }
         },
         "once": {
@@ -865,7 +989,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           },
           "dependencies": {
             "wrappy": {
@@ -888,7 +1012,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           },
           "dependencies": {
             "has-flag": {
@@ -905,7 +1029,7 @@
           "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -930,32 +1054,32 @@
       "integrity": "sha1-cUG03/W4bjLQ6Z12S4NnZ8MNIBo=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "commander": "2.9.0",
-        "cst": "0.4.10",
-        "estraverse": "4.2.0",
-        "exit": "0.1.2",
-        "glob": "5.0.15",
+        "chalk": "~1.1.0",
+        "cli-table": "~0.3.1",
+        "commander": "~2.9.0",
+        "cst": "^0.4.3",
+        "estraverse": "^4.1.0",
+        "exit": "~0.1.2",
+        "glob": "^5.0.1",
         "htmlparser2": "3.8.3",
-        "js-yaml": "3.4.6",
-        "jscs-jsdoc": "2.0.0",
-        "jscs-preset-wikimedia": "1.0.0",
-        "jsonlint": "1.6.2",
-        "lodash": "3.10.1",
-        "minimatch": "3.0.4",
-        "natural-compare": "1.2.2",
-        "pathval": "0.1.1",
-        "prompt": "0.2.14",
-        "reserved-words": "0.1.2",
-        "resolve": "1.5.0",
-        "strip-bom": "2.0.0",
-        "strip-json-comments": "1.0.4",
-        "to-double-quotes": "2.0.0",
-        "to-single-quotes": "2.0.1",
-        "vow": "0.4.17",
-        "vow-fs": "0.3.6",
-        "xmlbuilder": "3.1.0"
+        "js-yaml": "~3.4.0",
+        "jscs-jsdoc": "^2.0.0",
+        "jscs-preset-wikimedia": "~1.0.0",
+        "jsonlint": "~1.6.2",
+        "lodash": "~3.10.0",
+        "minimatch": "~3.0.0",
+        "natural-compare": "~1.2.2",
+        "pathval": "~0.1.1",
+        "prompt": "~0.2.14",
+        "reserved-words": "^0.1.1",
+        "resolve": "^1.1.6",
+        "strip-bom": "^2.0.0",
+        "strip-json-comments": "~1.0.2",
+        "to-double-quotes": "^2.0.0",
+        "to-single-quotes": "^2.0.0",
+        "vow": "~0.4.8",
+        "vow-fs": "~0.3.4",
+        "xmlbuilder": "^3.1.0"
       },
       "dependencies": {
         "chalk": {
@@ -964,11 +1088,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -989,7 +1113,7 @@
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -1006,7 +1130,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -1048,7 +1172,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           },
           "dependencies": {
             "graceful-readlink": {
@@ -1065,9 +1189,9 @@
           "integrity": "sha1-nAXIJSkKdi8KhcCqu4wP4DWuhRY=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babylon": "6.18.0",
-            "source-map-support": "0.4.18"
+            "babel-runtime": "^6.9.2",
+            "babylon": "^6.8.1",
+            "source-map-support": "^0.4.0"
           },
           "dependencies": {
             "babel-runtime": {
@@ -1076,8 +1200,8 @@
               "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
               "dev": true,
               "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               },
               "dependencies": {
                 "core-js": {
@@ -1106,7 +1230,7 @@
               "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
               "dev": true,
               "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
               },
               "dependencies": {
                 "source-map": {
@@ -1137,11 +1261,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "inflight": {
@@ -1150,8 +1274,8 @@
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
@@ -1174,7 +1298,7 @@
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               },
               "dependencies": {
                 "wrappy": {
@@ -1199,11 +1323,11 @@
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.3.0",
-            "domutils": "1.5.1",
-            "entities": "1.0.0",
-            "readable-stream": "1.1.14"
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
           },
           "dependencies": {
             "domelementtype": {
@@ -1218,7 +1342,7 @@
               "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
               "dev": true,
               "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
               }
             },
             "domutils": {
@@ -1227,8 +1351,8 @@
               "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
               "dev": true,
               "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
               },
               "dependencies": {
                 "dom-serializer": {
@@ -1237,8 +1361,8 @@
                   "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
                   "dev": true,
                   "requires": {
-                    "domelementtype": "1.1.3",
-                    "entities": "1.1.1"
+                    "domelementtype": "~1.1.1",
+                    "entities": "~1.1.1"
                   },
                   "dependencies": {
                     "domelementtype": {
@@ -1269,10 +1393,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               },
               "dependencies": {
                 "core-util-is": {
@@ -1309,9 +1433,9 @@
           "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3",
-            "inherit": "2.2.6"
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0",
+            "inherit": "^2.2.2"
           },
           "dependencies": {
             "argparse": {
@@ -1320,7 +1444,7 @@
               "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
               "dev": true,
               "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
               },
               "dependencies": {
                 "sprintf-js": {
@@ -1351,8 +1475,8 @@
           "integrity": "sha1-9T684CmqMSW9iCkLpQ1k1FEKSHE=",
           "dev": true,
           "requires": {
-            "comment-parser": "0.3.2",
-            "jsdoctypeparser": "1.2.0"
+            "comment-parser": "^0.3.1",
+            "jsdoctypeparser": "~1.2.0"
           },
           "dependencies": {
             "comment-parser": {
@@ -1361,7 +1485,7 @@
               "integrity": "sha1-PAPwd2uGo239mgosl8YwfzMggv4=",
               "dev": true,
               "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.4"
               },
               "dependencies": {
                 "readable-stream": {
@@ -1370,13 +1494,13 @@
                   "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "safe-buffer": "5.1.1",
-                    "string_decoder": "1.0.3",
-                    "util-deprecate": "1.0.2"
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~1.0.6",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.0.3",
+                    "util-deprecate": "~1.0.1"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -1415,7 +1539,7 @@
                       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                       "dev": true,
                       "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                       }
                     },
                     "util-deprecate": {
@@ -1434,7 +1558,7 @@
               "integrity": "sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=",
               "dev": true,
               "requires": {
-                "lodash": "3.10.1"
+                "lodash": "^3.7.0"
               }
             }
           }
@@ -1451,8 +1575,8 @@
           "integrity": "sha1-VzcEUIX1XrRVxosf9OvAG9UOiDA=",
           "dev": true,
           "requires": {
-            "JSV": "4.0.2",
-            "nomnom": "1.8.1"
+            "JSV": ">= 4.0.x",
+            "nomnom": ">= 1.5.x"
           },
           "dependencies": {
             "JSV": {
@@ -1467,8 +1591,8 @@
               "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
               "dev": true,
               "requires": {
-                "chalk": "0.4.0",
-                "underscore": "1.6.0"
+                "chalk": "~0.4.0",
+                "underscore": "~1.6.0"
               },
               "dependencies": {
                 "chalk": {
@@ -1477,9 +1601,9 @@
                   "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "1.0.0",
-                    "has-color": "0.1.7",
-                    "strip-ansi": "0.1.1"
+                    "ansi-styles": "~1.0.0",
+                    "has-color": "~0.1.0",
+                    "strip-ansi": "~0.1.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -1524,7 +1648,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           },
           "dependencies": {
             "brace-expansion": {
@@ -1533,7 +1657,7 @@
               "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
               "dev": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               },
               "dependencies": {
@@ -1571,11 +1695,11 @@
           "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
           "dev": true,
           "requires": {
-            "pkginfo": "0.4.1",
-            "read": "1.0.7",
-            "revalidator": "0.1.8",
-            "utile": "0.2.1",
-            "winston": "0.8.3"
+            "pkginfo": "0.x.x",
+            "read": "1.0.x",
+            "revalidator": "0.1.x",
+            "utile": "0.2.x",
+            "winston": "0.8.x"
           },
           "dependencies": {
             "pkginfo": {
@@ -1590,7 +1714,7 @@
               "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
               },
               "dependencies": {
                 "mute-stream": {
@@ -1613,12 +1737,12 @@
               "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
               "dev": true,
               "requires": {
-                "async": "0.2.10",
-                "deep-equal": "1.0.1",
-                "i": "0.3.6",
-                "mkdirp": "0.5.1",
-                "ncp": "0.4.2",
-                "rimraf": "2.6.2"
+                "async": "~0.2.9",
+                "deep-equal": "*",
+                "i": "0.3.x",
+                "mkdirp": "0.x.x",
+                "ncp": "0.4.x",
+                "rimraf": "2.x.x"
               },
               "dependencies": {
                 "async": {
@@ -1668,7 +1792,7 @@
                   "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
                   "dev": true,
                   "requires": {
-                    "glob": "7.1.2"
+                    "glob": "^7.0.5"
                   },
                   "dependencies": {
                     "glob": {
@@ -1677,12 +1801,12 @@
                       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
                       "dev": true,
                       "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                       },
                       "dependencies": {
                         "fs.realpath": {
@@ -1697,8 +1821,8 @@
                           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0",
-                            "wrappy": "1.0.2"
+                            "once": "^1.3.0",
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -1721,7 +1845,7 @@
                           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           },
                           "dependencies": {
                             "wrappy": {
@@ -1750,13 +1874,13 @@
               "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
               "dev": true,
               "requires": {
-                "async": "0.2.10",
-                "colors": "0.6.2",
-                "cycle": "1.0.3",
-                "eyes": "0.1.8",
-                "isstream": "0.1.2",
-                "pkginfo": "0.3.1",
-                "stack-trace": "0.0.10"
+                "async": "0.2.x",
+                "colors": "0.6.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "pkginfo": "0.3.x",
+                "stack-trace": "0.0.x"
               },
               "dependencies": {
                 "async": {
@@ -1817,7 +1941,7 @@
           "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           },
           "dependencies": {
             "path-parse": {
@@ -1834,7 +1958,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           },
           "dependencies": {
             "is-utf8": {
@@ -1875,10 +1999,10 @@
           "integrity": "sha1-LUxZviLivyYY3fWXq0uqkjvnIA0=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "uuid": "2.0.3",
-            "vow": "0.4.17",
-            "vow-queue": "0.4.3"
+            "glob": "^7.0.5",
+            "uuid": "^2.0.2",
+            "vow": "^0.4.7",
+            "vow-queue": "^0.4.1"
           },
           "dependencies": {
             "glob": {
@@ -1887,12 +2011,12 @@
               "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -1907,8 +2031,8 @@
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
+                    "once": "^1.3.0",
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -1931,7 +2055,7 @@
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "requires": {
-                    "wrappy": "1.0.2"
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -1962,7 +2086,7 @@
               "integrity": "sha1-S6j2S1bpISwNvlfxQFruvVTM540=",
               "dev": true,
               "requires": {
-                "vow": "0.4.17"
+                "vow": "^0.4.17"
               }
             }
           }
@@ -1973,7 +2097,7 @@
           "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
           "dev": true,
           "requires": {
-            "lodash": "3.10.1"
+            "lodash": "^3.5.0"
           }
         }
       }
@@ -1984,14 +2108,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
       },
       "dependencies": {
         "cli": {
@@ -2001,7 +2125,7 @@
           "dev": true,
           "requires": {
             "exit": "0.1.2",
-            "glob": "7.1.2"
+            "glob": "^7.1.1"
           },
           "dependencies": {
             "glob": {
@@ -2010,12 +2134,12 @@
               "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -2030,8 +2154,8 @@
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
                   "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
+                    "once": "^1.3.0",
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -2054,7 +2178,7 @@
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
                   "requires": {
-                    "wrappy": "1.0.2"
+                    "wrappy": "1"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -2081,7 +2205,7 @@
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "dev": true,
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           },
           "dependencies": {
             "date-now": {
@@ -2104,11 +2228,11 @@
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.3.0",
-            "domutils": "1.5.1",
-            "entities": "1.0.0",
-            "readable-stream": "1.1.14"
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
           },
           "dependencies": {
             "domelementtype": {
@@ -2123,7 +2247,7 @@
               "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
               "dev": true,
               "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
               }
             },
             "domutils": {
@@ -2132,8 +2256,8 @@
               "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
               "dev": true,
               "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
               },
               "dependencies": {
                 "dom-serializer": {
@@ -2142,8 +2266,8 @@
                   "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
                   "dev": true,
                   "requires": {
-                    "domelementtype": "1.1.3",
-                    "entities": "1.1.1"
+                    "domelementtype": "~1.1.1",
+                    "entities": "~1.1.1"
                   },
                   "dependencies": {
                     "domelementtype": {
@@ -2174,10 +2298,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               },
               "dependencies": {
                 "core-util-is": {
@@ -2220,7 +2344,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           },
           "dependencies": {
             "brace-expansion": {
@@ -2229,7 +2353,7 @@
               "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
               "dev": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               },
               "dependencies": {
@@ -2263,220 +2387,113 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
+      "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "browser-stdout": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
-          }
-        },
-        "diff": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
-            }
-          }
-        },
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
-          "dev": true
-        },
-        "he": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-              "dev": true
-            }
-          }
-        }
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
+      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
       }
     },
     "promise": {
@@ -2485,7 +2502,7 @@
       "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       },
       "dependencies": {
         "asap": {
@@ -2501,7 +2518,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       },
       "dependencies": {
         "is-promise": {
@@ -2511,283 +2528,53 @@
         }
       }
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sinon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
-      "integrity": "sha1-kTIRG0u+E8dJwoSCEIZCUBZQabE=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
-        "diff": "3.4.0",
-        "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.1.3",
-        "native-promise-only": "0.8.1",
-        "nise": "1.2.0",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
-        "text-encoding": "0.6.4",
-        "type-detect": "4.0.3"
-      },
-      "dependencies": {
-        "build": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-          "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
-          "dev": true,
-          "requires": {
-            "cssmin": "0.3.2",
-            "jsmin": "1.0.1",
-            "jxLoader": "0.1.1",
-            "moo-server": "1.3.0",
-            "promised-io": "0.3.5",
-            "timespan": "2.3.0",
-            "uglify-js": "1.3.5",
-            "walker": "1.0.7",
-            "winston": "2.4.0",
-            "wrench": "1.3.9"
-          },
-          "dependencies": {
-            "cssmin": {
-              "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-              "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
-              "dev": true
-            },
-            "jsmin": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-              "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
-              "dev": true
-            },
-            "jxLoader": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-              "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
-              "dev": true,
-              "requires": {
-                "js-yaml": "0.3.7",
-                "moo-server": "1.3.0",
-                "promised-io": "0.3.5",
-                "walker": "1.0.7"
-              },
-              "dependencies": {
-                "js-yaml": {
-                  "version": "0.3.7",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-                  "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
-                  "dev": true
-                }
-              }
-            },
-            "moo-server": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-              "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
-              "dev": true
-            },
-            "promised-io": {
-              "version": "0.3.5",
-              "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
-              "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
-              "dev": true
-            },
-            "timespan": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-              "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
-              "dev": true
-            },
-            "uglify-js": {
-              "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-              "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
-              "dev": true
-            },
-            "walker": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-              "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-              "dev": true,
-              "requires": {
-                "makeerror": "1.0.11"
-              },
-              "dependencies": {
-                "makeerror": {
-                  "version": "1.0.11",
-                  "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-                  "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-                  "dev": true,
-                  "requires": {
-                    "tmpl": "1.0.4"
-                  },
-                  "dependencies": {
-                    "tmpl": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-                      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "winston": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-              "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
-              "dev": true,
-              "requires": {
-                "async": "1.0.0",
-                "colors": "1.0.3",
-                "cycle": "1.0.3",
-                "eyes": "0.1.8",
-                "isstream": "0.1.2",
-                "stack-trace": "0.0.10"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-                  "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-                  "dev": true
-                },
-                "colors": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                  "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-                  "dev": true
-                },
-                "cycle": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-                  "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-                  "dev": true
-                },
-                "eyes": {
-                  "version": "0.1.8",
-                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-                  "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-                  "dev": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-                  "dev": true
-                },
-                "stack-trace": {
-                  "version": "0.0.10",
-                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-                  "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-                  "dev": true
-                }
-              }
-            },
-            "wrench": {
-              "version": "1.3.9",
-              "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-              "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
-              "dev": true
-            }
-          }
-        },
-        "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha1-sdhVB9rzlkgo3lSzfQ1zumfdpWw=",
-          "dev": true
-        },
-        "formatio": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-          "dev": true,
-          "requires": {
-            "samsam": "1.3.0"
-          }
-        },
-        "lodash.get": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-          "dev": true
-        },
-        "lolex": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
-          "integrity": "sha1-U/iTu+iMgDeBViQOEnEmuQXIMIc=",
-          "dev": true
-        },
-        "native-promise-only": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-          "dev": true
-        },
-        "nise": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-          "integrity": "sha1-B51srbvLErow448cmZ82rU1rqlM=",
-          "dev": true,
-          "requires": {
-            "formatio": "1.2.0",
-            "just-extend": "1.1.27",
-            "lolex": "1.6.0",
-            "path-to-regexp": "1.7.0",
-            "text-encoding": "0.6.4"
-          },
-          "dependencies": {
-            "just-extend": {
-              "version": "1.1.27",
-              "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-              "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
-              "dev": true
-            },
-            "lolex": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-              "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-              "dev": true
-            }
-          }
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            }
-          }
-        },
-        "samsam": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-          "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
-          "dev": true
-        },
-        "text-encoding": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-          "dev": true
-        },
-        "type-detect": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-          "dev": true
-        }
+        "@sinonjs/formatio": "^2.0.0",
+        "diff": "^3.1.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }


### PR DESCRIPTION
Closes #57 

Originally was going to remove Node 6 too, but maybe let's wait for end of life in April 2019.