### PR TITLE
feat: add option to allow configuring no results text

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,10 @@ class AutocompletePrompt extends Base {
    * When user press `enter` key
    */
   onSubmit(line /* : string */) {
+    var choice = this.currentChoices.getChoice(this.selected);
+    
     if (typeof this.opt.validate === 'function') {
-      var validationResult = this.opt.validate(line);
+      var validationResult = this.opt.validate(choice && choice.value || line);
       if (validationResult !== true) {
         this.render(
           validationResult || 'Enter something, tab to autocomplete!'
@@ -124,7 +126,6 @@ class AutocompletePrompt extends Base {
       }
     }
 
-    var choice = this.currentChoices.getChoice(this.selected);
     if (this.currentChoices.length <= this.selected && !this.opt.suggestOnly && choice !== undefined) {
       this.rl.write(line);
       this.search(line);

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ class AutocompletePrompt extends Base {
    * When user press `enter` key
    */
   onSubmit(line /* : string */) {
-    if (typeof this.opt.validate === 'function' && this.opt.suggestOnly) {
+    if (typeof this.opt.validate === 'function') {
       var validationResult = this.opt.validate(line);
       if (validationResult !== true) {
         this.render(
@@ -124,21 +124,23 @@ class AutocompletePrompt extends Base {
       }
     }
 
-    var choice = {};
-    if (this.currentChoices.length <= this.selected && !this.opt.suggestOnly) {
+    var choice = this.currentChoices.getChoice(this.selected);
+    if (this.currentChoices.length <= this.selected && !this.opt.suggestOnly && choice !== undefined) {
       this.rl.write(line);
       this.search(line);
       return;
     }
 
-    if (this.opt.suggestOnly) {
+    if (this.opt.suggestOnly || !choice) {
+      if (!choice) {
+        choice = {};
+      }
       choice.value = line || this.rl.line;
       this.answer = line || this.rl.line;
       this.answerName = line || this.rl.line;
       this.shortAnswer = line || this.rl.line;
       this.rl.line = '';
     } else {
-      choice = this.currentChoices.getChoice(this.selected);
       this.answer = choice.value;
       this.answerName = choice.name;
       this.shortAnswer = choice.short;

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class AutocompletePrompt extends Base {
       );
     } else {
       content += this.rl.line;
-      bottomContent += '  ' + chalk.yellow('No results...');
+      bottomContent += '  ' + chalk.yellow(this.opt.emptyText || 'No results...');
     }
 
     if (error) {

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class AutocompletePrompt extends Base {
     var choice = this.currentChoices.getChoice(this.selected);
     
     if (typeof this.opt.validate === 'function') {
-      var validationResult = this.opt.validate(choice && choice.value || line);
+      var validationResult = this.opt.validate(choice && choice.value || line, this.answers);
       if (validationResult !== true) {
         this.render(
           validationResult || 'Enter something, tab to autocomplete!'


### PR DESCRIPTION
Hello 👋 I was recently using this in a project and wanted this specific functionality. The use case being: when there are no results, I want to indicate to the user that it is a regular input and they can enter custom text. 