### PR TITLE
Add rxjs to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1874,10 +1874,9 @@
       }
     },
     "rxjs": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
-      "dev": true,
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -2048,8 +2047,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ansi-escapes": "^3.0.0",
     "chalk": "^2.0.0",
     "figures": "^2.0.0",
-    "run-async": "^2.3.0"
+    "run-async": "^2.3.0",
+    "rxjs": "^6.3.2"
   },
   "peerDependencies": {
     "inquirer": "^5.0.0 || ^6.0.0"


### PR DESCRIPTION
Moving inquirer to dev- and peerDependencies caused rxjs to become a dev-dependency ( https://github.com/mokkabonna/inquirer-autocomplete-prompt/commit/ae9ff83e9a1a7eae38e3d89b0c353001afdc10a8#diff-32607347f8126e6534ebc7ebaec4853dR1880 ). In some cases, this leads to errors because rxjs is not installed at a place that can be reached from inquirer-autocomplete-prompt. This happened for example at https://github.com/125m125/splconfigurator/pull/145, where rxjs is installed in the node_modules folder of inquirer: 
```console
> npm list rxjs
splconfigurator@0.0.3
└─┬ inquirer@6.2.0
  └── rxjs@6.3.2 

>  find node_modules/ -type d -name 'rxjs'
node_modules/inquirer/node_modules/rxjs
```
Which caused this error message ( https://travis-ci.org/125m125/splconfigurator/jobs/426576292#L446 ):
```javascript
> npm install
...
[!] Error: Cannot find module 'rxjs/operators'
Error: Cannot find module 'rxjs/operators'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/home/travis/build/125m125/splconfigurator/node_modules/inquirer-autocomplete-prompt/index.js:16:21)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Object.require.extensions..js (/home/travis/build/125m125/splconfigurator/node_modules/rollup/bin/rollup:1227:17)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
...
```
Adding rxjs as production dependency solves this problem.