### PR TITLE
Allow multiline choices

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,18 @@ class AutocompletePrompt extends Base {
     } else if (this.currentChoices.length) {
       var choicesStr = listRender(this.currentChoices, this.selected);
       content += this.rl.line;
+      var indexPosition = this.selected;
+      var realIndexPosition = 0;
+      this.currentChoices.choices.every((choice, index) => {
+        if (index > indexPosition) {
+          return false;
+        }
+        realIndexPosition += choice.name.split('\n').length;
+        return true;
+      });
       bottomContent += this.paginator.paginate(
         choicesStr,
-        this.selected,
+        realIndexPosition,
         this.opt.pageSize
       );
     } else {


### PR DESCRIPTION
https://github.com/SBoudrias/Inquirer.js/issues/494

This fix is essentially the same fix proposed in Inquirer
issue #494, which was for fixing the checkbox prompt when
choices include newlines. This fix does the same thing
for inquirer-autocomplete-prompt.