### PR TITLE
fix: stops the prompt on empty string answer

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class AutocompletePrompt extends Base {
 
     var events = observe(this.rl);
 
-    const dontHaveAnswer = () => !this.answer;
+    const dontHaveAnswer = () => this.answer === undefined;
 
     events.line
       .pipe(takeWhile(dontHaveAnswer))


### PR DESCRIPTION
If user chooses the empty string as an intentional answer, the autocomplete-questions still goes on and interferes in next questions, which can override next answers.

To reproduce the bug you can clone [the `bug-reproduce` branch in my repo fork](https://github.com/mamoruuu/inquirer-autocomplete-prompt/tree/bug-reproduce), run `node example.js` and follow the instructions.

![Peek 2019-12-25 00-15](https://user-images.githubusercontent.com/21964985/71419742-021e6c00-26ac-11ea-89b6-7733ae29b9d0.gif)