### PR TITLE
fix: add missing dependency rxjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2497,10 +2497,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
-      "dev": true,
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+      "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -2842,10 +2841,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "ansi-escapes": "^4.3.1",
     "chalk": "^4.0.0",
     "figures": "^3.2.0",
-    "run-async": "^2.4.0"
+    "run-async": "^2.4.0",
+    "rxjs": "^6.6.2"
   },
   "peerDependencies": {
     "inquirer": "^5.0.0 || ^6.0.0 || ^7.0.0"


### PR DESCRIPTION
**What's the problem this PR addresses?**

`inquirer-autocomplete-prompt` is trying to use `rxjs` without declaring it as a dependency

Fixes https://github.com/mokkabonna/inquirer-autocomplete-prompt/issues/109

**How did you fix it?**

Add missing dependency rxjs