### PR TITLE
feat: Add transformOnAutoComplete option

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,9 +257,13 @@ class AutocompletePrompt extends Base {
       if (this.currentChoices.getChoice(this.selected)) {
         this.rl.write(ansiEscapes.cursorLeft);
         var autoCompleted = this.currentChoices.getChoice(this.selected).value;
+        if (this.opt.transformOnAutoComplete)
+          autoCompleted = this.opt.transformOnAutoComplete(autoCompleted);
         this.rl.write(ansiEscapes.cursorForward(autoCompleted.length));
+        this.rl.write(ansiEscapes.cursorForward());
         this.rl.line = autoCompleted;
         this.render();
+        if (this.opt.transformOnAutoComplete) this.search(this.rl.line);
       }
     } else if (keyName === 'down' || (keyName === 'n' && e.key.ctrl)) {
       len = this.nbChoices;


### PR DESCRIPTION
I added the option "transformOnAutoComplete" because I am using this
module for path auto-completion.
The transformOnAutoComplete option allows me to append a '/' to the
auto-completed user input in case the path is a directory, but it
could certainly be used for other things as well.
In case the transformOnAutoComplete option is used, another auto-completion
attempt is made using the new, transformed input.

The reason I added the line
'this.rl.write(ansiEscapes.cursorForward());'
is because there has been a bug where the cursor would not move the
specified amount of columns if the auto-completion contained special
characters like '.' or '/'. In those cases, the cursor would be moved in
the middle of the auto-completed input. I have no idea why my "fix"
works, but adding this line resolved the issue.