### PR TITLE
feat: Add transformOnAutoComplete option

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,9 +257,12 @@ class AutocompletePrompt extends Base {
       if (this.currentChoices.getChoice(this.selected)) {
         this.rl.write(ansiEscapes.cursorLeft);
         var autoCompleted = this.currentChoices.getChoice(this.selected).value;
+        if (this.opt.transformOnAutoComplete)
+          autoCompleted = this.opt.transformOnAutoComplete(autoCompleted);
         this.rl.write(ansiEscapes.cursorForward(autoCompleted.length));
         this.rl.line = autoCompleted;
         this.render();
+        if (this.opt.transformOnAutoComplete) this.search(this.rl.line);
       }
     } else if (keyName === 'down' || (keyName === 'n' && e.key.ctrl)) {
       len = this.nbChoices;


### PR DESCRIPTION
I added the option "transformOnAutoComplete" because I am using this
module for path auto-completion.
The transformOnAutoComplete option allows me to append a '/' to the
auto-completed user input in case the path is a directory, but it
could certainly be used for other things as well.
In case the transformOnAutoComplete option is used, another auto-completion
attempt is made using the new, transformed input.

![](https://media.giphy.com/media/JoDpgSAM7usikySjtH/giphy.gif)
