### PR TITLE
Fix suggestOnly tab issue #74

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,12 +275,15 @@ class AutocompletePrompt extends Base {
 
     if (keyName === 'tab' && this.opt.suggestOnly) {
       if (this.currentChoices.getChoice(this.selected)) {
-        this.rl.write(ansiEscapes.cursorLeft);
         const autoCompleted = this.currentChoices.getChoice(
           this.selected
         ).value;
-        this.rl.write(ansiEscapes.cursorForward(autoCompleted.length));
-        this.rl.line = autoCompleted;
+        this.rl.input.emit('keypress', '\b', {name: 'backspace'}); // Remove redundant tab.
+        if (autoCompleted.includes(this.rl.line)) {
+          this.rl.line = '';
+          this.rl.write(autoCompleted);
+          this.rl.input.emit('keypress', '\b', {name: 'right'}); // Calibrate cursor to right position.
+        }
         this.render();
       }
     } else if (keyName === 'down' || (keyName === 'n' && e.key.ctrl)) {


### PR DESCRIPTION
Issue: #74

---

@kapalex 's pr: https://github.com/mokkabonna/inquirer-autocomplete-prompt/pull/122 (didn't merged by conflict) try to fix. 

But involved a bug:

```javascript
this.rl.input.emit('keypress', '\b', { name: 'backspace' });
if (autoCompleted.includes(this.rl.line)) {
  this.rl.write(autoCompleted.replace(this.rl.line, '')); // Bugged line
}
```

Case passed

``` javascript
// when:
this.rl.line === 'a'; autoCompleted === 'apple';

// bugged line goes to:
this.rl.write('pple');
// equals to:
this.rl.line = 'a' + 'pple';

// result passed:
this.rl.line === 'apple' === autoCompleted

```

Case failed

``` javascript
// when:
this.rl.line === 'p'; autoCompleted === 'apple';

// bugged line goes to:
this.rl.write('aple');
// equals to:
this.rl.line = 'a' + 'aple';

// result failed:
this.rl.line === 'aaple' !== autoCompleted

```

---

This pr is inspired by his solution, fixed the issue:

``` javascript
this.rl.input.emit('keypress', '\b', {name: 'backspace'}); // Remove redundant tab.
if (autoCompleted.includes(this.rl.line)) {
  this.rl.line = '';
  this.rl.write(autoCompleted);
  this.rl.input.emit('keypress', '\b', {name: 'right'}); // Calibrate cursor to right position.
}
```
